### PR TITLE
Fix documentation comment

### DIFF
--- a/src/main/scala/com/sosnoski/concur/article1/TimedTest.scala
+++ b/src/main/scala/com/sosnoski/concur/article1/TimedTest.scala
@@ -14,7 +14,7 @@ package com.sosnoski.concur.article1
 import scala.io.Source
 
 /** Test application runner. The main() method takes command line parameters giving the details of the
-  * test to be executed. The actual test classes must be subclasses of TimedTestBase.
+  * test to be executed. The actual test classes must be subclasses of TimingTestBase.
   */
 object TimedTest {
 


### PR DESCRIPTION
The correct name is TimingTestBase instead of TimedTestBase
